### PR TITLE
Add custom server and database

### DIFF
--- a/pdm_tools/tools.py
+++ b/pdm_tools/tools.py
@@ -108,8 +108,8 @@ def query(sql: str,
     def connect_to_db(result, server=server, database=database):
         try:
             # Request
-            server = 'pdmprod.database.windows.net'
-            database = "pdm"
+            server = server
+            database = database
             driver = 'ODBC Driver 18 for SQL Server'  # Primary driver if available
             driver_fallback = 'ODBC Driver 17 for SQL Server'  # Fallback driver if available
             connection_string = f"DRIVER={driver};SERVER={server};DATABASE={database}"


### PR DESCRIPTION
The optional arguments server and database are added to the query and connect_to_database with default values as used today with pdm.