### PR TITLE
Updates/fixes as proposed by Dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ sqlalchemy = "^2.0.36"
 urllib3 = "^2.3.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.4.4"
-black = "^24.1.1"
+pytest = "^9.0.3"
+black = "^26.3.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
A possible reason that dependabot would not create PRs for these, is because of the dependency constraint