### PR TITLE
update security on the package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,6 +77,24 @@ Follow PEP 8 as enforced by `black`. Key conventions used in this codebase:
 - Test thoroughly with `pytest` to ensure no breaking changes
 - Document any breaking changes in PR description
 
+## Versioning
+
+Bump the `version` field under `[tool.poetry]` in `pyproject.toml` for every
+change, following [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.MICRO`):
+
+- **MAJOR**: Increment for breaking changes that are **not** backward compatible
+  (e.g. removing or renaming public functions, changing function signatures or
+  return types). Reset MINOR and MICRO to `0`.
+- **MINOR**: Increment when new functionality or features are added, such as new
+  functions within existing modules/classes. Always backward compatible within
+  the same MAJOR version. Reset MICRO to `0`.
+- **MICRO** (patch): Increment for bug fixes and minor, non-breaking changes that
+  improve existing functionality. No new features — only improvements and fixes.
+
+Example: `2.5.4` → `2.5.5` (bug fix), → `2.6.0` (new feature), → `3.0.0`
+(breaking change).
+
+
 ## Important Notes
 - This package must run from Equinor managed environments
 - Authentication requires ODBC Driver for SQL Server (v17 or v18)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sql = '''
 SELECT top(100) * 
 FROM PDMVW.WELL_PROD_DAY 
 WHERE COUNTRY = :countrycode 
-AND PROD_DAY = :startdate"
+AND PROD_DAY = :startdate
 '''
 df = query(sql, params={'countrycode': 'NO',
                  'startdate': dt.datetime(2022, 1, 1)})

--- a/pdm_datareader/tools.py
+++ b/pdm_datareader/tools.py
@@ -87,7 +87,7 @@ def get_token(username: str = "") -> str:
     return _token
 
 
-def get_engine(conn_url: str = "", tokenstruct=None, reset: bool = False):
+def get_engine(conn_url: str = "", tokenstruct: Optional[bytes] = None, reset: bool = False) -> "sqlalchemy.engine.Engine":
     """Get a cached SQLAlchemy engine, creating one if needed.
 
     The engine is cached at module level and scoped to the token it was

--- a/pdm_datareader/tools.py
+++ b/pdm_datareader/tools.py
@@ -12,6 +12,7 @@ from msal_bearer import BearerAuth, get_user_name
 
 
 _engine = None
+_engine_token = None
 _token = ""
 _user_name = ""
 
@@ -63,9 +64,33 @@ def get_token(username: str = "") -> str:
 
 
 def get_engine(conn_url: str = "", tokenstruct=None, reset: bool = False):
-    global _engine
+    """Get a cached SQLAlchemy engine, creating one if needed.
+
+    The engine is cached at module level and scoped to the token it was
+    created with. It is rebuilt automatically when ``reset`` is True or when
+    ``tokenstruct`` differs from the token of the cached engine, to avoid
+    reusing another identity's connection.
+
+    Args:
+        conn_url (str, optional): ODBC connection string used to build the
+            engine when a new one is created. Defaults to "".
+        tokenstruct (optional): Packed access token struct passed to the driver
+            via ``attrs_before``. Defaults to None.
+        reset (bool, optional): Force disposal of any existing engine before
+            returning. Defaults to False.
+
+    Returns:
+        sqlalchemy.engine.Engine: The cached or newly created engine.
+    """
+    global _engine, _engine_token
 
     if reset:
+        reset_engine()
+
+    # Rebuild the engine if it was created for a different token (identity).
+    # The token is baked into the connection via attrs_before, so reusing a
+    # cached engine across users would run queries under the wrong identity.
+    if _engine is not None and tokenstruct is not None and tokenstruct != _engine_token:
         reset_engine()
 
     if _engine is None:
@@ -74,17 +99,20 @@ def get_engine(conn_url: str = "", tokenstruct=None, reset: bool = False):
             URL.create("mssql+pyodbc", query={"odbc_connect": conn_url}),
             connect_args={"attrs_before": {SQL_COPT_SS_ACCESS_TOKEN: tokenstruct}},
         )
+        _engine_token = tokenstruct
 
     return _engine
 
 
 def reset_engine():
     """Reset connection engine"""
-    global _engine
+    global _engine, _engine_token
 
     if _engine is not None:
         _engine.dispose()
         _engine = None
+
+    _engine_token = None
 
 
 def connect_to_db(token, verbose=False):
@@ -164,9 +192,21 @@ def query(
     verbose: Optional[bool] = False,
 ) -> pd.DataFrame:
     """Wrapper to pd.read_sql. Query database and get result as pd.DataFrame
+        Security:
+        Always pass user-supplied values through ``params`` so they are bound
+        as SQL parameters. Never build ``sql`` by string-formatting or
+        concatenating untrusted input, as this exposes the query to SQL
+        injection.
+
+        Safe::
+
+            query("SELECT * FROM t WHERE id = :id", params={"id": user_id})
+
+        Unsafe::
+
+            query(f"SELECT * FROM t WHERE id = {user_id}")
 
     Args:
-        sql (str): SQL query to run
         params (Optional[dict], optional): SQL parameters as dictionary. Defaults to None.
         verbose (Optional[bool], optional): Set true to print debugging log to stdout. Defaults to False.
 

--- a/pdm_datareader/tools.py
+++ b/pdm_datareader/tools.py
@@ -116,7 +116,8 @@ def get_engine(conn_url: str = "", tokenstruct: Optional[bytes] = None, reset: b
     # including transitions to or from None. The token is baked into the
     # connection via attrs_before, so reusing a cached engine across identities
     # would run queries under the wrong user.
-    if _engine is not None and _token_key(tokenstruct) != _engine_token:
+    token_key = _token_key(tokenstruct)
+    if _engine is not None and token_key != _engine_token:
         reset_engine()
 
     # Rebuild the engine once it exceeds its TTL so a stale, likely-expired
@@ -133,7 +134,7 @@ def get_engine(conn_url: str = "", tokenstruct: Optional[bytes] = None, reset: b
             URL.create("mssql+pyodbc", query={"odbc_connect": conn_url}),
             connect_args={"attrs_before": {SQL_COPT_SS_ACCESS_TOKEN: tokenstruct}},
         )
-        _engine_token = _token_key(tokenstruct)
+        _engine_token = token_key
         _engine_created_at = time.monotonic()
 
     return _engine

--- a/pdm_datareader/tools.py
+++ b/pdm_datareader/tools.py
@@ -1,4 +1,6 @@
+import hashlib
 import struct
+import time
 from typing import Optional
 
 import pandas as pd
@@ -11,10 +13,32 @@ from sqlalchemy.engine import URL
 from msal_bearer import BearerAuth, get_user_name
 
 
+# Maximum lifetime of a cached engine, in seconds. Kept below the typical
+# Azure AD access token lifetime (~60 min) so an expired token is not reused.
+_ENGINE_TTL_SECONDS = 30 * 60
+
 _engine = None
 _engine_token = None
+_engine_created_at = 0.0
 _token = ""
 _user_name = ""
+
+
+def _token_key(tokenstruct) -> Optional[str]:
+    """Derive a non-reversible key identifying a token struct.
+
+    Used to detect when the cached engine belongs to a different identity
+    without keeping the raw access token in memory.
+
+    Args:
+        tokenstruct: Packed access token struct, or None.
+
+    Returns:
+        Optional[str]: A hex digest of the token, or None if no token.
+    """
+    if tokenstruct is None:
+        return None
+    return hashlib.sha256(tokenstruct).hexdigest()
 
 
 def set_token(token: str):
@@ -67,9 +91,10 @@ def get_engine(conn_url: str = "", tokenstruct=None, reset: bool = False):
     """Get a cached SQLAlchemy engine, creating one if needed.
 
     The engine is cached at module level and scoped to the token it was
-    created with. It is rebuilt automatically when ``reset`` is True or when
-    ``tokenstruct`` differs from the token of the cached engine, to avoid
-    reusing another identity's connection.
+    created with. It is rebuilt automatically when ``reset`` is True, when
+    ``tokenstruct`` differs from the token of the cached engine, or when the
+    cached engine is older than ``_ENGINE_TTL_SECONDS`` (to avoid reusing an
+    expired access token).
 
     Args:
         conn_url (str, optional): ODBC connection string used to build the
@@ -82,15 +107,24 @@ def get_engine(conn_url: str = "", tokenstruct=None, reset: bool = False):
     Returns:
         sqlalchemy.engine.Engine: The cached or newly created engine.
     """
-    global _engine, _engine_token
+    global _engine, _engine_token, _engine_created_at
 
     if reset:
         reset_engine()
 
-    # Rebuild the engine if it was created for a different token (identity).
-    # The token is baked into the connection via attrs_before, so reusing a
-    # cached engine across users would run queries under the wrong identity.
-    if _engine is not None and tokenstruct is not None and tokenstruct != _engine_token:
+    # Rebuild the engine if it was created for a different token (identity),
+    # including transitions to or from None. The token is baked into the
+    # connection via attrs_before, so reusing a cached engine across identities
+    # would run queries under the wrong user.
+    if _engine is not None and _token_key(tokenstruct) != _engine_token:
+        reset_engine()
+
+    # Rebuild the engine once it exceeds its TTL so a stale, likely-expired
+    # token is not reused for new connections.
+    if (
+        _engine is not None
+        and time.monotonic() - _engine_created_at > _ENGINE_TTL_SECONDS
+    ):
         reset_engine()
 
     if _engine is None:
@@ -99,20 +133,22 @@ def get_engine(conn_url: str = "", tokenstruct=None, reset: bool = False):
             URL.create("mssql+pyodbc", query={"odbc_connect": conn_url}),
             connect_args={"attrs_before": {SQL_COPT_SS_ACCESS_TOKEN: tokenstruct}},
         )
-        _engine_token = tokenstruct
+        _engine_token = _token_key(tokenstruct)
+        _engine_created_at = time.monotonic()
 
     return _engine
 
 
 def reset_engine():
     """Reset connection engine"""
-    global _engine, _engine_token
+    global _engine, _engine_token, _engine_created_at
 
     if _engine is not None:
         _engine.dispose()
         _engine = None
 
     _engine_token = None
+    _engine_created_at = 0.0
 
 
 def connect_to_db(token, verbose=False):
@@ -191,8 +227,10 @@ def query(
     params: Optional[dict] = None,
     verbose: Optional[bool] = False,
 ) -> pd.DataFrame:
-    """Wrapper to pd.read_sql. Query database and get result as pd.DataFrame
-        Security:
+    """
+    Wrapper to pd.read_sql. Query database and get result as pd.DataFrame.
+
+    Security:
         Always pass user-supplied values through ``params`` so they are bound
         as SQL parameters. Never build ``sql`` by string-formatting or
         concatenating untrusted input, as this exposes the query to SQL
@@ -207,6 +245,8 @@ def query(
             query(f"SELECT * FROM t WHERE id = {user_id}")
 
     Args:
+        sql (str): SQL query to run. Use bind parameters (e.g. ``:name``) for
+            any dynamic values instead of string interpolation.
         params (Optional[dict], optional): SQL parameters as dictionary. Defaults to None.
         verbose (Optional[bool], optional): Set true to print debugging log to stdout. Defaults to False.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdm-datareader"
-version = "2.5.4"
+version = "2.5.5"
 description = "A small python package to execute queries to PDM without having to re-authenticate every time"
 authors = ["PDM TEAM <AWL@equinor.com>"]
 license = "MIT"

--- a/tests/test_engine_cache.py
+++ b/tests/test_engine_cache.py
@@ -1,0 +1,53 @@
+import pytest
+
+from pdm_datareader import tools
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Ensure a clean engine cache before and after each test."""
+    tools.reset_engine()
+    tools.set_token("")
+    yield
+    tools.reset_engine()
+    tools.set_token("")
+
+
+def test_engine_is_cached_for_same_token():
+    token = b"token-a"
+    engine1 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+    engine2 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+
+    assert engine1 is engine2
+
+
+def test_engine_rebuilt_for_different_token():
+    engine_a = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=b"token-a")
+    engine_b = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=b"token-b")
+
+    # A different identity must not reuse the cached engine.
+    assert engine_a is not engine_b
+
+
+def test_reset_engine_clears_cache():
+    token = b"token-a"
+    engine1 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+    tools.reset_engine()
+    engine2 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+
+    assert engine1 is not engine2
+
+
+def test_reset_flag_rebuilds_engine():
+    token = b"token-a"
+    engine1 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+    engine2 = tools.get_engine(
+        "DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token, reset=True
+    )
+
+    assert engine1 is not engine2
+
+
+def test_set_token_returned_by_get_token():
+    tools.set_token("my-explicit-token")
+    assert tools.get_token() == "my-explicit-token"

--- a/tests/test_engine_cache.py
+++ b/tests/test_engine_cache.py
@@ -29,6 +29,43 @@ def test_engine_rebuilt_for_different_token():
     assert engine_a is not engine_b
 
 
+def test_engine_rebuilt_on_none_transition():
+    # None -> token and token -> None must both rebuild the engine.
+    engine_none = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=None)
+    engine_token = tools.get_engine(
+        "DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=b"token-a"
+    )
+    engine_none_again = tools.get_engine(
+        "DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=None
+    )
+
+    assert engine_none is not engine_token
+    assert engine_token is not engine_none_again
+
+
+def test_engine_token_is_not_stored_raw():
+    token = b"super-secret-token"
+    tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+
+    # Only a derived digest should be kept, never the raw token bytes.
+    assert tools._engine_token != token
+    assert tools._engine_token == tools._token_key(token)
+
+
+def test_engine_rebuilt_after_ttl_expiry(monkeypatch):
+    token = b"token-a"
+    engine1 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+
+    # Simulate time passing beyond the engine TTL.
+    monkeypatch.setattr(
+        tools, "_engine_created_at", tools._engine_created_at - tools._ENGINE_TTL_SECONDS - 1
+    )
+    engine2 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)
+
+    assert engine1 is not engine2
+
+
+
 def test_reset_engine_clears_cache():
     token = b"token-a"
     engine1 = tools.get_engine("DRIVER=x;SERVER=y;DATABASE=z", tokenstruct=token)


### PR DESCRIPTION
This PR strengthens connection-identity handling in pdm_datareader by scoping the cached SQLAlchemy engine to the access token used to create it, and adds guidance on writing parameterized queries to reduce SQL injection risk.

### Changes:

- Cache the SQLAlchemy engine alongside the token used to create it, and rebuild the engine when the token changes or when explicitly reset.
- Add pytest coverage to ensure engine caching/reset behavior is correct across token changes.
- Extend .github/copilot-instructions.md with version-bumping guidance aligned with SemVer.